### PR TITLE
refactor: use data-* for cypress and Dot component

### DIFF
--- a/cypress/integration/walkthrough.js
+++ b/cypress/integration/walkthrough.js
@@ -11,31 +11,31 @@ describe("Walkthrough Tests", () => {
 
     cy.get("h2").should("contain.text", "Learn and build in web3.");
 
-    cy.get(".js-dot0").click();
+    cy.get("[data-test-id=0]").click();
     cy.get("h2").should("contain.text", "Connect your wallet");
 
-    cy.get(".js-dot1").click();
+    cy.get("[data-test-id=1]").click();
     cy.get("h2").should("contain.text", "Receive tokens");
 
-    cy.get(".js-dot2").click();
+    cy.get("[data-test-id=2]").click();
     cy.get("h2").should("contain.text", "Receive gas");
 
-    cy.get(".js-dot3").click();
+    cy.get("[data-test-id=3]").click();
     cy.get("h2").should("contain.text", "Use gas to send tokens");
 
-    cy.get(".js-dot4").click();
+    cy.get("[data-test-id=4]").click();
     cy.get("h2").should("contain.text", "Mint an NFT");
 
-    cy.get(".js-dot5").click();
+    cy.get("[data-test-id=5]").click();
     cy.get("h2").should("contain.text", "Burn a token");
 
-    cy.get(".js-dot6").click();
+    cy.get("[data-test-id=6]").click();
     cy.get("h2").should("contain.text", "Swap a token");
 
-    cy.get(".js-dot7").click();
+    cy.get("[data-test-id=7]").click();
     cy.get("h2").should("contain.text", "Vote in a proposal");
 
-    cy.get(".js-dot8").click();
+    cy.get("[data-test-id=8]").click();
     cy.get("h2").should("contain.text", "Create your own token");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@openzeppelin/contracts": "^4.5.0",
         "@web3-react/core": "^6.1.9",
         "@web3-react/injected-connector": "^6.0.7",
+        "classnames": "^2.3.1",
         "next": "12.0.8",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -3700,6 +3701,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -23545,6 +23551,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-stack": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@openzeppelin/contracts": "^4.5.0",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
+    "classnames": "^2.3.1",
     "next": "12.0.8",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,8 @@ import { UserRejectedRequestError } from "@web3-react/injected-connector";
 import { useEffect, useState } from "react";
 import { injected } from "../connectors";
 import useMetaMaskOnboarding from "../hooks/useMetaMaskOnboarding";
-import * as React from 'react'
+import * as React from "react";
+import classNames from "classnames";
 
 const FWEB3_TOKEN_ADDRESS = "0x4a14ac36667b574b08443a15093e417db909d7a3";
 
@@ -22,14 +23,10 @@ type AccountProps = {
 const Account = ({ triedToEagerConnect }: AccountProps) => {
   const { query } = useRouter();
 
-  const { active, error, activate, account, setError } =
-    useWeb3React();
+  const { active, error, activate, account, setError } = useWeb3React();
 
-  const {
-    isWeb3Available,
-    startOnboarding,
-    stopOnboarding,
-  } = useMetaMaskOnboarding();
+  const { isWeb3Available, startOnboarding, stopOnboarding } =
+    useMetaMaskOnboarding();
 
   // manage connecting state for injected connector
   const [connecting, setConnecting] = useState(false);
@@ -50,24 +47,58 @@ const Account = ({ triedToEagerConnect }: AccountProps) => {
 
   if (typeof account !== "string") {
     return (
-      <button className="pulse" onClick={isWeb3Available ? (
-        () => {
-          setConnecting(true);
+      <button
+        className="pulse"
+        onClick={
+          isWeb3Available
+            ? () => {
+                setConnecting(true);
 
-          activate(injected, undefined, true).catch((error) => {
-            // ignore the error if it is a user rejected request
-            if (error instanceof UserRejectedRequestError) {
-              setConnecting(false);
-            } else {
-              setError(error);
-            }
-          });
+                activate(injected, undefined, true).catch((error) => {
+                  // ignore the error if it is a user rejected request
+                  if (error instanceof UserRejectedRequestError) {
+                    setConnecting(false);
+                  } else {
+                    setError(error);
+                  }
+                });
+              }
+            : startOnboarding
         }
-      ) : startOnboarding}>
+      >
         Connect your wallet
       </button>
     );
   }
+};
+
+type DotProps = {
+  index: number;
+  setActiveDot: (index: number) => void;
+  activeDot: number;
+  gameTileCompletionStates: number[];
+  children: React.ReactNode;
+};
+
+const Dot: React.FC<DotProps> = ({
+  index,
+  setActiveDot,
+  activeDot,
+  gameTileCompletionStates,
+  children,
+}) => {
+  return (
+    <div
+      data-test-id={`js-dot${index}`}
+      onClick={() => setActiveDot(index)}
+      className={classNames("game-tile", {
+        active: activeDot === index,
+        completed: gameTileCompletionStates[index],
+      })}
+    >
+      <div className="tooltip">{children}</div>
+    </div>
+  );
 };
 
 export default function Home() {
@@ -85,24 +116,38 @@ export default function Home() {
     { revalidateOnFocus: false }
   );
 
-  const [activeDot, setActiveDot] = useState(-1)
+  const [activeDot, setActiveDot] = useState(-1);
 
   let gameTileCompletionStates = [
-    (isConnected || query.wallet) ? 1 : 0,
-    parseBalanceToNum((polygonData && polygonData["tokenBalance"]) ?? 0) >= 100 ? 1 : 0,
+    isConnected || query.wallet ? 1 : 0,
+    parseBalanceToNum((polygonData && polygonData["tokenBalance"]) ?? 0) >= 100
+      ? 1
+      : 0,
     polygonData && polygonData["hasUsedFaucet"] ? 1 : 0,
     polygonData && polygonData["hasSentTokens"] ? 1 : 0,
     polygonData && polygonData["hasMintedNFT"] ? 1 : 0,
     polygonData && polygonData["hasBurnedTokens"] ? 1 : 0,
     polygonData && polygonData["hasSwappedTokens"] ? 1 : 0,
     polygonData && polygonData["hasVotedInPoll"] ? 1 : 0,
-    polygonData && polygonData["hasDeployedContract"] ? 1 : 0
+    polygonData && polygonData["hasDeployedContract"] ? 1 : 0,
   ];
 
   let completedTiles = 0;
   for (let i = 0; i < gameTileCompletionStates.length; i++) {
     completedTiles += gameTileCompletionStates[i];
   }
+
+  const toolTipTexts = [
+    "Connect your wallet",
+    "Get 100 $FWEB3 tokens",
+    "Use the faucet to get .1 $MATIC",
+    "Send 100 $FWEB3 tokens to someone",
+    "Mint a Fweb3 NFT",
+    "Burn at least one $FWEB3 token",
+    "Swap a $FWEB3 token for some $MATIC",
+    "Vote on a Fweb3 poll",
+    "Write and deploy a smart contract",
+  ];
 
   return (
     <div>
@@ -122,17 +167,17 @@ export default function Home() {
       </Head>
 
       <nav>
-        <h1>
-          fweb3
-        </h1>
+        <h1>fweb3</h1>
 
         <p>
-          <strong>{Math.round(completedTiles / 9 * 100)}%</strong> complete
+          <strong>{Math.round((completedTiles / 9) * 100)}%</strong> complete
         </p>
 
-        {query.wallet !== undefined && query.wallet !== account && query.wallet.length > 0 && (
-          <p style={{color: "#fff"}}>{query.wallet}</p>
-        )}
+        {query.wallet !== undefined &&
+          query.wallet !== account &&
+          query.wallet.length > 0 && (
+            <p style={{ color: "#fff" }}>{query.wallet}</p>
+          )}
 
         {isConnected || query.wallet ? (
           <TokenBalance
@@ -147,131 +192,54 @@ export default function Home() {
       <main>
         <section>
           <div className="game-grid">
-            <div
-              onClick={() => setActiveDot(0)}
-              className={
-                "game-tile js-dot0 " +
-                (activeDot === 0 ? "active " : "") +
-                (gameTileCompletionStates[0] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Connect your wallet</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(1)}
-              className={
-                "game-tile js-dot1 " +
-                (activeDot === 1 ? "active " : "") +
-                (gameTileCompletionStates[1] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Get 100 $FWEB3 tokens</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(2)}
-              className={
-                "game-tile js-dot2 " +
-                (activeDot === 2 ? "active " : "") +
-                (gameTileCompletionStates[2] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Use the faucet to get .1 $MATIC</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(3)}
-              className={
-                "game-tile js-dot3 " +
-                (activeDot === 3 ? "active " : "") +
-                (gameTileCompletionStates[3] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Send 100 $FWEB3 tokens to someone</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(4)}
-              className={
-                "game-tile js-dot4 " +
-                (activeDot === 4 ? "active " : "") +
-                (gameTileCompletionStates[4] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Mint a Fweb3 NFT</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(5)}
-              className={
-                "game-tile js-dot5 " +
-                (activeDot === 5 ? "active " : "") +
-                (gameTileCompletionStates[5] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Burn at least one $FWEB3 token</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(6)}
-              className={
-                "game-tile js-dot6 " +
-                (activeDot === 6 ? "active " : "") +
-                (gameTileCompletionStates[6] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Swap a $FWEB3 token for some $MATIC</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(7)}
-              className={
-                "game-tile js-dot7 " +
-                (activeDot === 7 ? "active " : "") +
-                (gameTileCompletionStates[7] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Vote on a Fweb3 poll</div>
-            </div>
-
-            <div
-              onClick={() => setActiveDot(8)}
-              className={
-                "game-tile js-dot8 " +
-                (activeDot === 8 ? "active " : "") +
-                (gameTileCompletionStates[8] ? "completed" : "")
-              }
-            >
-              <div className="tooltip">Write and deploy a smart contract</div>
-            </div>
+            {toolTipTexts.map((toolTipText, index) => (
+              <Dot
+                key={`${index}-${toolTipText}`}
+                index={index}
+                gameTileCompletionStates={gameTileCompletionStates}
+                activeDot={activeDot}
+                setActiveDot={setActiveDot}
+              >
+                {toolTipText}
+              </Dot>
+            ))}
           </div>
 
-          <a className="share-button" onClick={() => {
-            let gameTiles = document.getElementsByClassName("game-tile");
-            let completedGameTiles = [];
-            for (let i = 0; i < gameTiles.length; i++) {
-              completedGameTiles.push(gameTiles[i].classList.contains("completed"));
-            }
-
-            let shareText = `Fweb3 ${ completedGameTiles.reduce((a, b) => a + b) }/9\n\n`;
-
-            for (let i = 0; i < gameTiles.length; i++) {
-              shareText += completedGameTiles[i] ? "🟣" : "⚫️";
-
-              if (i % 3 == 2 && i != gameTiles.length - 1) {
-                shareText += "\n";
+          <a
+            className="share-button"
+            onClick={() => {
+              let gameTiles = document.getElementsByClassName("game-tile");
+              let completedGameTiles = [];
+              for (let i = 0; i < gameTiles.length; i++) {
+                completedGameTiles.push(
+                  gameTiles[i].classList.contains("completed")
+                );
               }
-            }
 
-            if (navigator.share) {
-              navigator.share({
-                text: shareText
-              });
-            } else {
-              window.open("https://twitter.com/intent/tweet?text=" + encodeURIComponent(shareText));
-            }
-          }}>
+              let shareText = `Fweb3 ${completedGameTiles.reduce(
+                (a, b) => a + b
+              )}/9\n\n`;
+
+              for (let i = 0; i < gameTiles.length; i++) {
+                shareText += completedGameTiles[i] ? "🟣" : "⚫️";
+
+                if (i % 3 == 2 && i != gameTiles.length - 1) {
+                  shareText += "\n";
+                }
+              }
+
+              if (navigator.share) {
+                navigator.share({
+                  text: shareText,
+                });
+              } else {
+                window.open(
+                  "https://twitter.com/intent/tweet?text=" +
+                    encodeURIComponent(shareText)
+                );
+              }
+            }}
+          >
             Share your progress
           </a>
         </section>
@@ -279,7 +247,11 @@ export default function Home() {
           {activeDot === -1 && (
             <>
               <h2>Learn and build in web3.</h2>
-              <p>There are 9 dots to light up by doing things on a blockchain (in this case, Polygon). Once you light them all up, you win additional $FWEB3 tokens and a commemorative NFT.</p>
+              <p>
+                There are 9 dots to light up by doing things on a blockchain (in
+                this case, Polygon). Once you light them all up, you win
+                additional $FWEB3 tokens and a commemorative NFT.
+              </p>
             </>
           )}
           {activeDot === 0 && (
@@ -338,27 +310,40 @@ export default function Home() {
           )}
           {!gameTileCompletionStates[0] && !query.wallet && (
             <div>
-              <p>It&apos;s free to play. Login with MetaMask to get started (you&apos;ll be prompted to install it if you don&apos;t have it already):</p>
+              <p>
+                It&apos;s free to play. Login with MetaMask to get started
+                (you&apos;ll be prompted to install it if you don&apos;t have it
+                already):
+              </p>
               <p>
                 <Account triedToEagerConnect={triedToEagerConnect} />
               </p>
-              {(chainId !== undefined && chainId !== 137 && !query.wallet) && (
-                <p style={{color: "#f55", marginTop: "1rem"}}>Switch to Polygon via MetaMask to play this game.</p>
+              {chainId !== undefined && chainId !== 137 && !query.wallet && (
+                <p style={{ color: "#f55", marginTop: "1rem" }}>
+                  Switch to Polygon via MetaMask to play this game.
+                </p>
               )}
             </div>
           )}
           {completedTiles === 9 && !query.wallet && (
             <div>
-              <p><strong style={{color: "white"}}>You&apos;ve completed all the dots! Paste your wallet address into #finish-line in Discord.</strong></p>
+              <p>
+                <strong style={{ color: "white" }}>
+                  You&apos;ve completed all the dots! Paste your wallet address
+                  into #finish-line in Discord.
+                </strong>
+              </p>
             </div>
           )}
         </section>
       </main>
       <footer>
-        <a href="https://s-h-l.notion.site/Walkthrough-058a7ba0a8fe4d798370e4f6a5fda8b0">Walkthrough</a>
+        <a href="https://s-h-l.notion.site/Walkthrough-058a7ba0a8fe4d798370e4f6a5fda8b0">
+          Walkthrough
+        </a>
         <a href="https://discord.gg/dNvYpeg2RC">Discord</a>
         <a href="https://github.com/slavingia/fweb3.xyz/issues">GitHub</a>
       </footer>
     </div>
-  )
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,6 +2745,11 @@
     "isobject" "^3.0.0"
     "static-extend" "^0.1.1"
 
+"classnames@^2.3.1":
+  "integrity" "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+  "resolved" "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
+  "version" "2.3.1"
+
 "clean-stack@^2.0.0":
   "integrity" "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
   "resolved" "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz"


### PR DESCRIPTION
i dunno. i cant even see the app locally due to api key limit so im coding blind. there's things i dont like about what i did for sure, and other structural stuff i'd address like probably should find a cleaner way to store the static content per dot better, may or may not need to store the state for whether the dot is done or not together with static content.

eg

```js

const dot0Body = <p>things, <img src="" /> and stuff </p>
const dot1Body = <p>just text here</p>

const dotsContent = {
  isConnected: {
    id: 'isConnected',
    tooltip: "Connect your wallet",
    title: "Connect your wallet",
    body: dot0Body
  },
  hasUsedFaucet: {
    id: 'hasUsedFaucet',
    tooltip: "Get 100 $FWEB3 tokens",
    title: "Receive tokens (for free!)",
    body: dot1Body
  },
}

const dots = [
  'isConnected',
  'hasUsedFaucet'
]

const gameCompletionState = {
  isConnected: true,
  hasUsedFaucet: false,
}
```

lets you do stuff like

```jsx
const [activeDot, setActiveDot] = React.useState('isConnected')

// render the grid of dots
dots.map(id => {
  const {id, tooltip} = dotsContent[id]
  return (
    <DotComponent 
      active={id === activeDot} 
      completed={gameCompletionState[id]} 
      tooltip={tooltip} 
      onClick={() => setActiveDot(id)}
    />
  )
})

// render the appropriate walkthrough content
<WalkthroughComponent title={dotsContent[activeDot].title}>
  {dotsContent[activeDot].body}
</WalkthroughComponent>
```

its also a lot easier to read and find actual content among a bunch of UI code